### PR TITLE
無料枠対応のRSS取得とタグ付けレート制御

### DIFF
--- a/rss.py
+++ b/rss.py
@@ -1,6 +1,8 @@
 import datetime as dt
 import json
 import os
+import re
+import time
 import requests
 import xml.etree.ElementTree as ET
 from dotenv import load_dotenv
@@ -12,38 +14,44 @@ load_dotenv()
 API_KEY = os.getenv('GEMINI_API_KEY')
 if not API_KEY:
     raise RuntimeError('環境変数 GEMINI_API_KEY が設定されていません (.env を確認してください)')
-import os
-from dotenv import load_dotenv
-
-load_dotenv()
-API_KEY = os.getenv('API_KEY')
 #ニュース取得
-def get_topics(rss_url):
+def get_topics(rss_url, retries=3, timeout=10):
     topics = []
-    res = requests.get(rss_url)
-    root = ET.fromstring(res.text)
-    for item in root[0].findall('item'):
-        title = '' if item.find('title') is None else item.find('title').text
-        link = '' if item.find('link') is None else item.find('link').text
-        description = '' if item.find('description') is None else item.find('description').text
-        pub_date = '' if item.find('pubDate') is None else item.find('pubDate').text
-        if '+' in pub_date:
-            pub_date = dt.datetime.strptime(pub_date, '%a, %d %b %Y %H:%M:%S %z')
-        else:
-            pub_date = dt.datetime.strptime(pub_date, '%a, %d %b %Y %H:%M:%S %Z')
-        topic = {
-            'title': title,
-            'link': link,
-            'description': description,
-            'pub_date': pub_date.isoformat(),
-        }
-        topics.append(topic)
+    last_error = None
+    for attempt in range(1, retries + 1):
+        try:
+            res = requests.get(rss_url, timeout=timeout)
+            res.raise_for_status()
+            root = ET.fromstring(res.text)
+            for item in root[0].findall('item'):
+                title = '' if item.find('title') is None else item.find('title').text
+                link = '' if item.find('link') is None else item.find('link').text
+                description = '' if item.find('description') is None else item.find('description').text
+                content_node = item.find('{http://purl.org/rss/1.0/modules/content/}encoded')
+                body = description if content_node is None else (content_node.text or '')
+                pub_date = '' if item.find('pubDate') is None else item.find('pubDate').text
+                if '+' in pub_date:
+                    pub_date = dt.datetime.strptime(pub_date, '%a, %d %b %Y %H:%M:%S %z')
+                else:
+                    pub_date = dt.datetime.strptime(pub_date, '%a, %d %b %Y %H:%M:%S %Z')
+                topic = {
+                    'title': title,
+                    'link': link,
+                    'description': description,
+                    'body': body,
+                    'pub_date': pub_date.isoformat(),
+                }
+                topics.append(topic)
+            return topics
+        except Exception as e:
+            last_error = e
+            print(f"[WARN] RSS fetch failed (attempt {attempt}/{retries}) for {rss_url}: {e}")
+    print(f"[ERROR] RSS fetch exhausted retries for {rss_url}: {last_error}")
     return topics
 
-#プロンプト送受信
-def chat(request_prompt):
-    GEMINI_API_KEY = API_KEY
-    client = genai.Client(api_key=GEMINI_API_KEY)
+#プロンプト送受信（簡易リトライ付き）
+def chat(request_prompt, retries=1, backoff_seconds=5):
+    client = genai.Client(api_key=API_KEY)
     content_string = request_prompt['messages'][0]['content']
     config = types.GenerateContentConfig(
         system_instruction=request_prompt['context'],
@@ -51,16 +59,26 @@ def chat(request_prompt):
         temperature=request_prompt['temperature'],
         top_p=request_prompt['topP'],
     )
-    try:
-        response = client.models.generate_content(
-            model='gemini-2.5-flash',
-            contents=content_string,
-            config=config,
-        )
-        return {'candidates': [{'text': response.text}]}
-    except Exception as e:
-        print(f"API呼び出し中にエラーが発生しました: {e}")
-        return None
+    last_error = None
+    for attempt in range(1, retries + 1):
+        try:
+            response = client.models.generate_content(
+                model='gemini-2.5-flash',
+                contents=content_string,
+                config=config,
+            )
+            return {'candidates': [{'text': response.text}]}
+        except Exception as e:
+            last_error = e
+            print(f"[WARN] API呼び出し中にエラーが発生しました (attempt {attempt}/{retries}): {e}")
+            if attempt < retries:
+                retry_after = backoff_seconds * attempt
+                match = re.search(r"Please retry in ([0-9.]+)s", str(e))
+                if match:
+                    retry_after = float(match.group(1))
+                time.sleep(retry_after)
+    print(f"[ERROR] API呼び出しが失敗しました: {last_error}")
+    return None
 
 #リクエスト作成
 def generate_request_prompt(prompt, content, tmp, p):
@@ -90,9 +108,16 @@ def tag_topic(content):
     """
     request_prompt = generate_request_prompt(system_prompt, content, 0, 1)
     chat_res = chat(request_prompt)
-    res_str = chat_res['candidates'][0]['text']
-    res_dict = json.loads(res_str)
-    return res_dict
+    if not chat_res or 'candidates' not in chat_res:
+        print("[WARN] タグ生成に失敗しました: 応答なし")
+        return []
+    try:
+        res_str = chat_res['candidates'][0].get('text', '[]')
+        res_dict = json.loads(res_str)
+        return res_dict
+    except Exception as e:
+        print(f"[WARN] タグ生成結果のパースに失敗しました: {e}")
+        return []
 
 #実行
 news_links = [
@@ -100,12 +125,17 @@ news_links = [
     'https://rss.itmedia.co.jp/rss/2.0/news_bursts.xml',
     'https://rss.itmedia.co.jp/rss/2.0/business.xml'
 ]
+limit_per_feed = 4
+RATE_LIMIT_SLEEP_SECONDS = 12  # free tier: ~5 RPM, so wait ~12s between tag calls
 all_topics = []
 for news_link in news_links:
-    topics = get_topics(news_link)[:2]
+    topics = get_topics(news_link)[:limit_per_feed]
     all_topics += topics
+if len(all_topics) < 10:
+    print(f"[WARN] collected topics are below expected count: {len(all_topics)} < 10")
 for topic in all_topics:
     content = topic['title'] + ' ' + topic['description']
     topic['tags'] = tag_topic(content)
+    time.sleep(RATE_LIMIT_SLEEP_SECONDS)
 with open('all_topics.json', 'w', encoding='utf-8') as f:
     json.dump(all_topics, f, indent=4, ensure_ascii=False)


### PR DESCRIPTION
## 概要
- RSS取得をフィードあたり4件に調整し、全体10件超を確保しつつ呼び出し回数を削減
- タグ生成APIのリトライを1回に制限し、各タグ生成の後に12秒スリープを挿入して無料枠(約5RPM)を超えないよう制御
- 取得データはタイトル・本文(content:encoded優先)・リンク・公開日時を含めて all_topics.json に保存
- RSS/タグ生成ともに失敗時はWARN/ERRORログを出力し、処理継続できるようにした

## テスト
- py rss.py  (APIクォータ状況によってタグ付けが失敗する場合あり)